### PR TITLE
Startup scripts: remove obsolete java option "-XstartOnFirstThread"

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -XstartOnFirstThread -jar Demo.jar --args "demo.dng"
+java -jar Starter.jar --args "demo.dng"

--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,2 @@
 @echo off
-java -XstartOnFirstThread -jar Demo.jar --args "demo.dng"
+java -jar Starter.jar --args "demo.dng"


### PR DESCRIPTION
Changes:

- remove obsolete option `-XstartOnFirstThread` (was needed on macOS only, obsolet via 5a3dbd8)
- rename `Demo.jar` to `Starter.jar`