### PR TITLE
Rename organisation: use 'Dungeon-CampusMinden' instead of 'Programmiermethoden'

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Programmiermethoden
+Copyright (c) 2023-2024 Dungeon-CampusMinden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <h1 align="center">Dungeon: StarterKit</h1>
 
-Das Dungeon: StarterKit liefert alles, was für den ersten Start des [Dungeon: Learning by Questing](https://github.com/Programmiermethoden/Dungeon) benötigt wird.
+Das Dungeon: StarterKit liefert alles, was für den ersten Start des [Dungeon: Learning by Questing](https://github.com/Dungeon-CampusMinden/Dungeon) benötigt wird.
 
-Im Hauptrepository [Dungeon](https://github.com/Programmiermethoden/Dungeon) finden Sie neben dem Sourcecode auch weitere Dokumentationen und Anleitungen.
+Im Hauptrepository [Dungeon](https://github.com/Dungeon-CampusMinden/Dungeon) finden Sie neben dem Sourcecode auch weitere Dokumentationen und Anleitungen.
 
 ## Start
-*   [Direkt Download als `.zip`](https://github.com/Programmiermethoden/Dungeon-StarterKit/archive/refs/heads/master.zip)
-*   Klonen per Git mit `git clone https://github.com/Programmiermethoden/Dungeon-StarterKit.git`
-*   [Folgen Sie dem Quickstart](https://github.com/Programmiermethoden/Dungeon/tree/master/dungeon/doc/quickstart.md)
-*   Die [Spielanleitung](https://github.com/Programmiermethoden/Dungeon/blob/master/dungeon/doc/how_to_play.md) erklärt die wichtigsten Grundlagen zum spielen. 
-* [Eigene Aufgaben definieren](https://github.com/Programmiermethoden/Dungeon/blob/master/dungeon/doc/dsl/task_definition.md)
+*   [Direkt Download als `.zip`](https://github.com/Dungeon-CampusMinden/Dungeon-StarterKit/archive/refs/heads/master.zip)
+*   Klonen per Git mit `git clone https://github.com/Dungeon-CampusMinden/Dungeon-StarterKit.git`
+*   [Folgen Sie dem Quickstart](https://github.com/Dungeon-CampusMinden/Dungeon/tree/master/dungeon/doc/quickstart.md)
+*   Die [Spielanleitung](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/doc/how_to_play.md) erklärt die wichtigsten Grundlagen zum spielen.
+* [Eigene Aufgaben definieren](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/dungeon/doc/dsl/task_definition.md)
 
 ## Demo Starten
 
@@ -31,10 +31,10 @@ This project is funded by [Stiftung für Innovation in der Hochschullehre](https
 
 ## License
 
-This [work](https://github.com/Programmiermethoden/Dungeon-StarterKit) by
+This [work](https://github.com/Dungeon-CampusMinden/Dungeon-StarterKit) by
 [André Matutat](https://github.com/AMatutat),
 [Malte Reinsch](https://github.com/malt-r), and
-[contributors](https://github.com/Programmiermethoden/Dungeon/graphs/contributors)
+[contributors](https://github.com/Dungeon-CampusMinden/Dungeon/graphs/contributors)
 is licensed under [MIT](LICENSE.md).
 
-<p align="right"><img src="https://github.com/Programmiermethoden/Dungeon/blob/master/doc/img/logo/cat_logo_64x64.png" alt="Logo"></p>
+<p align="right"><img src="https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/doc/img/logo/cat_logo_64x64.png" alt="Logo"></p>


### PR DESCRIPTION
We have renamed our organisation to 'Dungeon-CampusMinden'. This PR is intended to replace all instances of the old name ('Programming Methods') with the new name ('Dungeon-CampusMinden').

closes [#1315 ](https://github.com/Dungeon-CampusMinden/Dungeon/issues/1315)